### PR TITLE
update johnrengelman.shadow plugin

### DIFF
--- a/produce-consume-lang/scala/code/build.gradle
+++ b/produce-consume-lang/scala/code/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "com.google.cloud.tools.jib" version "3.3.1"
-    id "com.github.johnrengelman.shadow" version "6.1.0"
+    id "com.github.johnrengelman.shadow" version "8.1.1"
 }
 
 allprojects {

--- a/serialization/kstreams/code/build.gradle
+++ b/serialization/kstreams/code/build.gradle
@@ -12,7 +12,7 @@ plugins {
   id "application"
   id "idea"
   id "com.google.cloud.tools.jib" version "3.3.1"
-  id "com.github.johnrengelman.shadow" version "6.1.0"
+  id "com.github.johnrengelman.shadow" version "8.1.1"
   id "com.google.protobuf" version "0.9.2"
   id "com.github.davidmc24.gradle.plugin.avro" version "1.7.0"
 }


### PR DESCRIPTION
Changes: 2 lines in 2 tutorial files
- produce-consume-lang/scala/code/build.gradle
- serialization/kstreams/code/build.gradle

Why: Updates to latest shadow plugin version so build cmd can succeed. 