### PR TITLE
use full URL for image in aggregating count tutorial (#1)

### DIFF
--- a/aggregating-count/flinksql/README.md
+++ b/aggregating-count/flinksql/README.md
@@ -186,4 +186,4 @@ Run the following command to execute [FlinkSqlAggregatingCountTest#testCountAggr
 
   The query output should look like this:
 
-  ![](img/query-output.png)
+  ![Query output](https://raw.githubusercontent.com/confluentinc/tutorials/master/aggregating-count/flinksql/img/query-output.png)


### PR DESCRIPTION
This allows the image to render properly on Confluent Developer