### PR TITLE
Flink SQL clone instructions (#7)

### DIFF
--- a/aggregating-count/flinksql/README.md
+++ b/aggregating-count/flinksql/README.md
@@ -38,14 +38,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlAggregatingCountTest#testCountAggregation](src/test/java/io/confluent/developer/FlinkSqlAggregatingCountTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlAggregatingCountTest#testCountAggregation](src/test/java/io/confluent/developer/FlinkSqlAggregatingCountTest.java):
 
   ```plaintext
   ./gradlew clean :aggregating-count:flinksql:test
@@ -58,14 +65,21 @@ Run the following command to execute [FlinkSqlAggregatingCountTest#testCountAggr
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -123,11 +137,11 @@ Run the following command to execute [FlinkSqlAggregatingCountTest#testCountAggr
 
   ```plaintext
              title tickets_sold
-  ---------------- -----------
-            Aliens           1
-          Die Hard           3
-  The Big Lebowski           2
-     The Godfather           4
+  ---------------- ------------
+            Aliens            1
+          Die Hard            3
+  The Big Lebowski            2
+     The Godfather            4
   ```
 
   When you are finished, clean up the containers used for this tutorial by running:
@@ -141,12 +155,12 @@ Run the following command to execute [FlinkSqlAggregatingCountTest#testCountAggr
 <details>
   <summary>Confluent Cloud</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * A [Confluent Cloud](https://confluent.cloud/signup) account
   * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-  #### Run the commands
+  ### Run the commands
 
   In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
   pool that you have created.

--- a/aggregating-minmax/flinksql/README.md
+++ b/aggregating-minmax/flinksql/README.md
@@ -41,14 +41,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlAggregatingMinMaxTest#testMinMax](src/test/java/io/confluent/developer/FlinkSqlAggregatingMinMaxTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlAggregatingMinMaxTest#testMinMax](src/test/java/io/confluent/developer/FlinkSqlAggregatingMinMaxTest.java):
 
   ```plaintext
   ./gradlew clean :aggregating-minmax:flinksql:test
@@ -61,14 +68,21 @@ Run the following command to execute [FlinkSqlAggregatingMinMaxTest#testMinMax](
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -146,12 +160,12 @@ Run the following command to execute [FlinkSqlAggregatingMinMaxTest#testMinMax](
 <details>
   <summary>Confluent Cloud</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * A [Confluent Cloud](https://confluent.cloud/signup) account
   * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-  #### Run the commands
+  ### Run the commands
 
   In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
   pool that you have created.

--- a/cumulating-windows/flinksql/README.md
+++ b/cumulating-windows/flinksql/README.md
@@ -54,14 +54,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlCumulatingWindowTest#testCumulatingWindows](src/test/java/io/confluent/developer/FlinkSqlCumulatingWindowTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlCumulatingWindowTest#testCumulatingWindows](src/test/java/io/confluent/developer/FlinkSqlCumulatingWindowTest.java):
 
   ```plaintext
   ./gradlew clean :cunulating-windows:flinksql:test
@@ -74,14 +81,21 @@ Run the following command to execute [FlinkSqlCumulatingWindowTest#testCumulatin
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -161,12 +175,12 @@ Run the following command to execute [FlinkSqlCumulatingWindowTest#testCumulatin
 <details>
   <summary>Confluent Cloud</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * A [Confluent Cloud](https://confluent.cloud/signup) account
   * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-  #### Run the commands
+  ### Run the commands
 
   In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
   pool that you have created.

--- a/deduplication-windowed/flinksql/README.md
+++ b/deduplication-windowed/flinksql/README.md
@@ -50,14 +50,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 11, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlFindingDistinctTest#testFindDistinct](src/test/java/io/confluent/developer/FlinkSqlFindingDistinctTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlFindingDistinctTest#testFindDistinct](src/test/java/io/confluent/developer/FlinkSqlFindingDistinctTest.java):
 
   ```plaintext
   ./gradlew clean :deduplication-windowed:flinksql:test
@@ -70,14 +77,21 @@ Run the following command to execute [FlinkSqlFindingDistinctTest#testFindDistin
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -154,12 +168,12 @@ Run the following command to execute [FlinkSqlFindingDistinctTest#testFindDistin
 <details>
   <summary>Confluent Cloud</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * A [Confluent Cloud](https://confluent.cloud/signup) account
   * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-  #### Run the commands
+  ### Run the commands
 
   In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
   pool that you have created.

--- a/deduplication/flinksql/README.md
+++ b/deduplication/flinksql/README.md
@@ -46,14 +46,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlFindingDistinctTest#testFindDistinct](src/test/java/io/confluent/developer/FlinkSqlFindingDistinctTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlFindingDistinctTest#testFindDistinct](src/test/java/io/confluent/developer/FlinkSqlFindingDistinctTest.java):
 
   ```plaintext
   ./gradlew clean :deduplication:flinksql:test
@@ -66,14 +73,21 @@ Run the following command to execute [FlinkSqlFindingDistinctTest#testFindDistin
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -145,12 +159,12 @@ Run the following command to execute [FlinkSqlFindingDistinctTest#testFindDistin
 <details>
   <summary>Confluent Cloud</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * A [Confluent Cloud](https://confluent.cloud/signup) account
   * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-  #### Run the commands
+  ### Run the commands
 
   In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
   pool that you have created.

--- a/filtering/flinksql/README.md
+++ b/filtering/flinksql/README.md
@@ -36,14 +36,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlFilteringTest#testFilter](src/test/java/io/confluent/developer/FlinkSqlFilteringTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlFilteringTest#testFilter](src/test/java/io/confluent/developer/FlinkSqlFilteringTest.java):
 
   ```plaintext
   ./gradlew clean :filtering:flinksql:test
@@ -56,14 +63,21 @@ Run the following command to execute [FlinkSqlFilteringTest#testFilter](src/test
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -119,7 +133,7 @@ Run the following command to execute [FlinkSqlFilteringTest#testFilter](src/test
   The query output should look like this:
 
   ```plaintext
-      book_id                         author                          title
+       book_id                         author                          title
              1            George R. R. Martin         A Song of Ice and Fire
              3            George R. R. Martin                   Fire & Blood
              6            George R. R. Martin              A Dream of Spring
@@ -137,12 +151,12 @@ Run the following command to execute [FlinkSqlFilteringTest#testFilter](src/test
 <details>
   <summary>Confluent Cloud</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * A [Confluent Cloud](https://confluent.cloud/signup) account
   * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-  #### Run the commands
+  ### Run the commands
 
   In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
   pool that you have created.

--- a/hopping-windows/flinksql/README.md
+++ b/hopping-windows/flinksql/README.md
@@ -49,14 +49,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlHoppingWindowTest#testHoppingWindows](src/test/java/io/confluent/developer/FlinkSqlHoppingWindowTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlHoppingWindowTest#testHoppingWindows](src/test/java/io/confluent/developer/FlinkSqlHoppingWindowTest.java):
 
   ```plaintext
   ./gradlew clean :hopping-windows:flinksql:test
@@ -69,14 +76,21 @@ Run the following command to execute [FlinkSqlHoppingWindowTest#testHoppingWindo
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -156,12 +170,12 @@ Run the following command to execute [FlinkSqlHoppingWindowTest#testHoppingWindo
 <details>
   <summary>Confluent Cloud</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * A [Confluent Cloud](https://confluent.cloud/signup) account
   * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-  #### Run the commands
+  ### Run the commands
 
   In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
   pool that you have created.

--- a/joining-stream-stream/flinksql/README.md
+++ b/joining-stream-stream/flinksql/README.md
@@ -80,14 +80,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlIntervalJoinTest#testJoin](src/test/java/io/confluent/developer/FlinkSqlIntervalJoinTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlIntervalJoinTest#testJoin](src/test/java/io/confluent/developer/FlinkSqlIntervalJoinTest.java):
 
   ```plaintext
   ./gradlew clean :joining-stream-stream:flinksql:test
@@ -100,14 +107,21 @@ Run the following command to execute [FlinkSqlIntervalJoinTest#testJoin](src/tes
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -234,12 +248,12 @@ Run the following command to execute [FlinkSqlIntervalJoinTest#testJoin](src/tes
 <details>
   <summary>Confluent Cloud</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * A [Confluent Cloud](https://confluent.cloud/signup) account
   * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-  #### Run the commands
+  ### Run the commands
 
   In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
   pool that you have created.

--- a/merging/flinksql/README.md
+++ b/merging/flinksql/README.md
@@ -55,14 +55,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlMergeTablesTest#testMerge](src/test/java/io/confluent/developer/FlinkSqlMergeTablesTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlMergeTablesTest#testMerge](src/test/java/io/confluent/developer/FlinkSqlMergeTablesTest.java):
 
   ```plaintext
   ./gradlew clean :merging:flinksql:test
@@ -75,14 +82,21 @@ Run the following command to execute [FlinkSqlMergeTablesTest#testMerge](src/tes
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -217,12 +231,12 @@ Run the following command to execute [FlinkSqlMergeTablesTest#testMerge](src/tes
 <details>
   <summary>Confluent Cloud</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * A [Confluent Cloud](https://confluent.cloud/signup) account
   * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-  #### Run the commands
+  ### Run the commands
 
   In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
   pool that you have created.

--- a/optimize-producer-throughput/kafka/README.md
+++ b/optimize-producer-throughput/kafka/README.md
@@ -28,12 +28,12 @@ You can run the example backing this tutorial locally in Docker, or with Conflue
 <details>
   <summary>Docker</summary>
 
-#### Prerequisites
+### Prerequisites
 
 * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-#### Run the commands
+### Run the commands
 
 First, start Kafka:
 
@@ -87,12 +87,12 @@ Now run the same test but with producer configuration tuned for higher throughpu
 <details>
   <summary>Confluent Cloud</summary>
 
-#### Prerequisites
+### Prerequisites
 
 * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 * A [Confluent Cloud](https://confluent.cloud/signup) account
 
-#### Run the commands
+### Run the commands
 
 First, create a cluster if you haven't already. You can do this in the Confluent Cloud Console by navigating to your environment and then clicking `Add cluster`.
 

--- a/over-aggregations/flinksql/README.md
+++ b/over-aggregations/flinksql/README.md
@@ -55,47 +55,61 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-#### Prerequisites
+  ### Prerequisites
 
-* Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java.
-* Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
+  * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java.
+  * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-#### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlOverAggregationTest#testTopN](src/test/java/io/confluent/developer/FlinkSqlOverAggregationTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlOverAggregationTest#testTopN](src/test/java/io/confluent/developer/FlinkSqlOverAggregationTest.java):
 
   ```plaintext
   ./gradlew clean :over-aggregations:flinksql:test
   ```
 
-The test starts Kafka and Schema Registry with [Testcontainers](https://testcontainers.com/), runs the Flink SQL commands
-above against a local Flink `StreamExecutionEnvironment`, and ensures that the aggregation results are what we expect.
+  The test starts Kafka and Schema Registry with [Testcontainers](https://testcontainers.com/), runs the Flink SQL commands
+  above against a local Flink `StreamExecutionEnvironment`, and ensures that the aggregation results are what we expect.
 </details>
 
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-#### Prerequisites
+  ### Prerequisites
 
-* Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
-* [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
+  * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
+  * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-#### Run the commands
+  ### Run the commands
 
-First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
   ```
 
-Next, open the Flink SQL Client CLI:
+  Next, open the Flink SQL Client CLI:
 
   ```shell
   docker exec -it flink-sql-client sql-client.sh
   ```
 
-Finally, run following SQL statements to create the `movie_views` table backed by Kafka running in Docker, populate it with
-test data, and run the OVER aggregation query.
+  Finally, run following SQL statements to create the `movie_views` table backed by Kafka running in Docker, populate it with
+  test data, and run the OVER aggregation query.
 
   ```sql
   CREATE TABLE movie_views (
@@ -113,8 +127,7 @@ test data, and run the OVER aggregation query.
       'key.fields' = 'id',
       'value.format' = 'json',
       'value.fields-include' = 'EXCEPT_KEY'
-);
-
+  );
   ```
 
   ```sql
@@ -142,17 +155,17 @@ test data, and run the OVER aggregation query.
          (333, 'The Pride of Archbishop Carroll', 'History', TO_TIMESTAMP('2024-04-24 03:37:00'));
   ```
 
-```sql
-SELECT title, genre, movie_start, COUNT(*)
-  OVER (
-    PARTITION BY genre
-    ORDER BY movie_start
-    RANGE BETWEEN INTERVAL '1' HOUR PRECEDING AND CURRENT ROW
-    ) AS genre_count
-FROM movie_views;
+  ```sql
+  SELECT title, genre, movie_start, COUNT(*)
+    OVER (
+      PARTITION BY genre
+      ORDER BY movie_start
+      RANGE BETWEEN INTERVAL '1' HOUR PRECEDING AND CURRENT ROW
+      ) AS genre_count
+  FROM movie_views;
   ```
 
-The query output should look like this:
+  The query output should look like this:
 
   ```plaintext
                           title                          genre                   movie_start          genre_count
@@ -176,43 +189,41 @@ The query output should look like this:
                     Toy Story 3                      Animation       2024-04-23 23:12:00.000                    3
                      Fight Club                          Drama       2024-04-23 23:24:00.000                    2
             Pride and Prejudice                        Romance       2024-04-23 23:37:00.000                    1
-The Pride of Archbishop Carro~                       History       2024-04-24 03:37:00.000                    1
-
+  The Pride of Archbishop Carro~                       History       2024-04-24 03:37:00.000                    1
 ```                                                                                 
 
-When you are finished, clean up the containers used for this tutorial by running:
+  When you are finished, clean up the containers used for this tutorial by running:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml down
   ```
-
 </details>
 
 <details>
   <summary>Confluent Cloud</summary>
 
-#### Prerequisites
+  ### Prerequisites
 
-* A [Confluent Cloud](https://confluent.cloud/signup) account
-* A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
+  * A [Confluent Cloud](https://confluent.cloud/signup) account
+  * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-#### Run the commands
+  ### Run the commands
 
-In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
-pool that you have created.
+  In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
+  pool that you have created.
 
-Select the default catalog (Confluent Cloud environment) and database (Kafka cluster) to use with the dropdowns at the top right.
+  Select the default catalog (Confluent Cloud environment) and database (Kafka cluster) to use with the dropdowns at the top right.
 
-Finally, run following SQL statements to create the `movie_views` table, populate it with test data, and run the OVER aggregation query.
+  Finally, run following SQL statements to create the `movie_views` table, populate it with test data, and run the OVER aggregation query.
 
   ```sql
- CREATE TABLE movie_views (
+  CREATE TABLE movie_views (
         id INT,
         title STRING,
         genre STRING,
         movie_start TIMESTAMP(3),
         WATERMARK FOR movie_start as movie_start
- ) DISTRIBUTED BY (id) INTO 1 BUCKETS;
+  ) DISTRIBUTED BY (id) INTO 1 BUCKETS;
   ```
 
   ```sql
@@ -250,8 +261,8 @@ Finally, run following SQL statements to create the `movie_views` table, populat
   FROM movie_views;
   ```
 
-The query output should look like this:
+ The query output should look like this:
 
-![Query output](https://raw.githubusercontent.com/confluentinc/tutorials/master/over-aggregations/flinksql/img/query-output.png)
+ ![Query output](https://raw.githubusercontent.com/confluentinc/tutorials/master/over-aggregations/flinksql/img/query-output.png)
 
 </details>

--- a/pattern-matching/flinksql/README.md
+++ b/pattern-matching/flinksql/README.md
@@ -63,14 +63,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlFilteringTest#testFilter](src/test/java/io/confluent/developer/FlinkSqlFilteringTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlFilteringTest#testFilter](src/test/java/io/confluent/developer/FlinkSqlFilteringTest.java):
 
   ```plaintext
   ./gradlew clean :pattern-matching:flinksql:test
@@ -83,14 +90,21 @@ Run the following command to execute [FlinkSqlFilteringTest#testFilter](src/test
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -295,12 +309,12 @@ Run the following command to execute [FlinkSqlFilteringTest#testFilter](src/test
 <details>
   <summary>Confluent Cloud</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * A [Confluent Cloud](https://confluent.cloud/signup) account
   * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-  #### Run the commands
+  ### Run the commands
 
   In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
   pool that you have created.

--- a/session-windows/flinksql/README.md
+++ b/session-windows/flinksql/README.md
@@ -48,14 +48,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlMergeTablesTest#testMerge](src/test/java/io/confluent/developer/FlinkSqlMergeTablesTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlMergeTablesTest#testMerge](src/test/java/io/confluent/developer/FlinkSqlMergeTablesTest.java):
 
   ```plaintext
   ./gradlew clean :session-windows:flinksql:test
@@ -68,14 +75,21 @@ Run the following command to execute [FlinkSqlMergeTablesTest#testMerge](src/tes
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -107,39 +121,41 @@ Run the following command to execute [FlinkSqlMergeTablesTest#testMerge](src/tes
       'value.format' = 'json',
       'value.fields-include' = 'EXCEPT_KEY'
   );
- ``` 
-```sql
- INSERT INTO clicks VALUES
-        ('9.62.201.241','/acme/jeep-stuff/', TO_TIMESTAMP('2023-07-09 01:00:00')),
-        ('122.65.213.141', '/farm-for-all/chickens/', TO_TIMESTAMP('2023-07-09 02:00:10')),
-        ('122.65.213.141', '/farm-for-all/chickens/', TO_TIMESTAMP('2023-07-09 02:00:20')),
-        ('122.65.213.141', '/farm-for-all/chickens/', TO_TIMESTAMP('2023-07-09 02:01:00')),
-        ('9.62.201.241', '/acme/jeep-stuff/', TO_TIMESTAMP('2023-07-09 01:00:30')),
-        ('9.62.201.241', '/acme/jeep-stuff/', TO_TIMESTAMP('2023-07-09 01:01:00')),
-        ('21.229.87.11', '/amc-rio/movies/', TO_TIMESTAMP('2023-07-09 09:00:00')),
-        ('234.112.107.50', '/trips/packages/', TO_TIMESTAMP('2023-07-09 12:00:00')),
-        ('21.229.87.11', '/amc-rio/movies/', TO_TIMESTAMP('2023-07-09 09:00:30')),
-        ('122.65.213.141', '/farm-for-all/tractors/', TO_TIMESTAMP('2023-07-09 02:30:00')),
-        ('122.65.213.141', '/farm-for-all/tractors/', TO_TIMESTAMP('2023-07-10 02:31:00'));
-```
-```sql
-SELECT url,
-    COUNT(url) AS visited_count,
-    window_start,
-    window_end
-FROM TABLE(SESSION(TABLE clicks PARTITION BY url, DESCRIPTOR(click_ts), INTERVAL '2' MINUTES))
-GROUP BY url, window_start, window_end;
-```
+  ```
+
+  ```sql
+  INSERT INTO clicks VALUES
+      ('9.62.201.241','/acme/jeep-stuff/', TO_TIMESTAMP('2023-07-09 01:00:00')),
+      ('122.65.213.141', '/farm-for-all/chickens/', TO_TIMESTAMP('2023-07-09 02:00:10')),
+      ('122.65.213.141', '/farm-for-all/chickens/', TO_TIMESTAMP('2023-07-09 02:00:20')),
+      ('122.65.213.141', '/farm-for-all/chickens/', TO_TIMESTAMP('2023-07-09 02:01:00')),
+      ('9.62.201.241', '/acme/jeep-stuff/', TO_TIMESTAMP('2023-07-09 01:00:30')),
+      ('9.62.201.241', '/acme/jeep-stuff/', TO_TIMESTAMP('2023-07-09 01:01:00')),
+      ('21.229.87.11', '/amc-rio/movies/', TO_TIMESTAMP('2023-07-09 09:00:00')),
+      ('234.112.107.50', '/trips/packages/', TO_TIMESTAMP('2023-07-09 12:00:00')),
+      ('21.229.87.11', '/amc-rio/movies/', TO_TIMESTAMP('2023-07-09 09:00:30')),
+      ('122.65.213.141', '/farm-for-all/tractors/', TO_TIMESTAMP('2023-07-09 02:30:00')),
+      ('122.65.213.141', '/farm-for-all/tractors/', TO_TIMESTAMP('2023-07-10 02:31:00'));
+  ```
+
+  ```sql
+  SELECT url,
+      COUNT(url) AS visited_count,
+      window_start,
+      window_end
+  FROM TABLE(SESSION(TABLE clicks PARTITION BY url, DESCRIPTOR(click_ts), INTERVAL '2' MINUTES))
+  GROUP BY url, window_start, window_end;
+  ```
 
   The query output should look like this:
 
   ```plaintext
-              url              visited_count                           window_start                window_end      
-/acme/jeep-stuff/                       3                  2023-07-09 01:00:00.000   2023-07-09 01:03:00.000
-/farm-for-all/chickens/                 3                  2023-07-09 02:00:10.000   2023-07-09 02:03:00.000
-/farm-for-all/tractors/                 1                  2023-07-09 02:30:00.000   2023-07-09 02:32:00.000
-/amc-rio/movies/                        2                  2023-07-09 09:00:00.000   2023-07-09 09:02:30.000
-/trips/packages/                        1                  2023-07-09 12:00:00.000   2023-07-09 12:02:00.000
+                      url     visited_count                             window_start                window_end      
+  /acme/jeep-stuff/                       3                  2023-07-09 01:00:00.000   2023-07-09 01:03:00.000
+  /farm-for-all/chickens/                 3                  2023-07-09 02:00:10.000   2023-07-09 02:03:00.000
+  /farm-for-all/tractors/                 1                  2023-07-09 02:30:00.000   2023-07-09 02:32:00.000
+  /amc-rio/movies/                        2                  2023-07-09 09:00:00.000   2023-07-09 09:02:30.000
+  /trips/packages/                        1                  2023-07-09 12:00:00.000   2023-07-09 12:02:00.000
   ```
 
   When you are finished, clean up the containers used for this tutorial by running:

--- a/splitting/flinksql/README.md
+++ b/splitting/flinksql/README.md
@@ -62,14 +62,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlSplitStreamTest#testSplit](src/test/java/io/confluent/developer/FlinkSqlSplitStreamTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlSplitStreamTest#testSplit](src/test/java/io/confluent/developer/FlinkSqlSplitStreamTest.java):
 
   ```plaintext
   ./gradlew clean :splitting:flinksql:test
@@ -82,14 +89,21 @@ Run the following command to execute [FlinkSqlSplitStreamTest#testSplit](src/tes
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -188,12 +202,12 @@ Run the following command to execute [FlinkSqlSplitStreamTest#testSplit](src/tes
 <details>
   <summary>Confluent Cloud</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * A [Confluent Cloud](https://confluent.cloud/signup) account
   * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-  #### Run the commands
+  ### Run the commands
 
   In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
   pool that you have created.

--- a/top-N/flinksql/README.md
+++ b/top-N/flinksql/README.md
@@ -47,14 +47,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlTopNTest#testTopN](src/test/java/io/confluent/developer/FlinkSqlTopNTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlTopNTest#testTopN](src/test/java/io/confluent/developer/FlinkSqlTopNTest.java):
 
   ```plaintext
   ./gradlew clean :top-N:flinksql:test
@@ -67,14 +74,21 @@ Run the following command to execute [FlinkSqlTopNTest#testTopN](src/test/java/i
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -132,19 +146,19 @@ Run the following command to execute [FlinkSqlTopNTest#testTopN](src/test/java/i
   ```
 
   ```sql
-SELECT title, genre, num_views, category_rank
-FROM (
-       SELECT *,
-              ROW_NUMBER() OVER (PARTITION BY genre ORDER BY num_views DESC) as category_rank
-       FROM movie_views
-     )
-WHERE category_rank <= 3;
+  SELECT title, genre, num_views, category_rank
+  FROM (
+      SELECT *,
+             ROW_NUMBER() OVER (PARTITION BY genre ORDER BY num_views DESC) as category_rank
+      FROM movie_views
+  )
+  WHERE category_rank <= 3;
   ```
 
   The query output should look like this:
 
   ```plaintext
-                            title                          genre            num_views        category_rank
+                          title                          genre            num_views        category_rank
               Avengers: Endgame                         Action               200010                    1
                 The Dark Knight                         Action               100240                    2
                      Casablanca                        Romance               400400                    1
@@ -175,12 +189,12 @@ WHERE category_rank <= 3;
 <details>
   <summary>Confluent Cloud</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * A [Confluent Cloud](https://confluent.cloud/signup) account
   * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-  #### Run the commands
+  ### Run the commands
 
   In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
   pool that you have created.
@@ -190,12 +204,12 @@ WHERE category_rank <= 3;
   Finally, run following SQL statements to create the `movie_views` table, populate it with test data, and run the Top-N query.
 
   ```sql
- CREATE TABLE movie_views (
-            id INT,
-            title STRING,
-            genre STRING,
-            num_views BIGINT
- );
+  CREATE TABLE movie_views (
+      id INT,
+      title STRING,
+      genre STRING,
+      num_views BIGINT
+  );
   ```
 
   ```sql

--- a/tumbling-windows/flinksql/README.md
+++ b/tumbling-windows/flinksql/README.md
@@ -52,14 +52,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlTumblingWindowTest#testTumblingWindows](src/test/java/io/confluent/developer/FlinkSqlTumblingWindowTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlTumblingWindowTest#testTumblingWindows](src/test/java/io/confluent/developer/FlinkSqlTumblingWindowTest.java):
 
   ```plaintext
   ./gradlew clean :tumbling-windows:flinksql:test
@@ -72,14 +79,21 @@ Run the following command to execute [FlinkSqlTumblingWindowTest#testTumblingWin
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -165,12 +179,12 @@ Run the following command to execute [FlinkSqlTumblingWindowTest#testTumblingWin
 <details>
   <summary>Confluent Cloud</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * A [Confluent Cloud](https://confluent.cloud/signup) account
   * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
 
-  #### Run the commands
+  ### Run the commands
 
   In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
   pool that you have created.

--- a/windowed-top-N/flinksql/README.md
+++ b/windowed-top-N/flinksql/README.md
@@ -76,14 +76,21 @@ against Flink and Kafka running in Docker, or with Confluent Cloud.
 <details>
   <summary>Flink Table API-based test</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Java 17, e.g., follow the OpenJDK installation instructions [here](https://openjdk.org/install/) if you don't have Java. 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
 
-  #### Run the test
+  ### Run the test
 
-Run the following command to execute [FlinkSqlTopNTest#testTopN](src/test/java/io/confluent/developer/FlinkSqlTopNTest.java):
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Run the following command to execute [FlinkSqlTopNTest#testTopN](src/test/java/io/confluent/developer/FlinkSqlTopNTest.java):
 
   ```plaintext
   ./gradlew clean :windowed-top-N:flinksql:test
@@ -96,14 +103,21 @@ Run the following command to execute [FlinkSqlTopNTest#testTopN](src/test/java/i
 <details>
   <summary>Flink SQL Client CLI</summary>
 
-  #### Prerequisites
+  ### Prerequisites
 
   * Docker running via [Docker Desktop](https://docs.docker.com/desktop/) or [Docker Engine](https://docs.docker.com/engine/install/)
   * [Docker Compose](https://docs.docker.com/compose/install/). Ensure that the command `docker compose version` succeeds.
 
-  #### Run the commands
+  ### Run the commands
 
-  First, start Flink and Kafka:
+  Clone the `confluentinc/tutorials` GitHub repository (if you haven't already) and navigate to the `tutorials` directory:
+
+  ```shell
+  git clone git@github.com:confluentinc/tutorials.git
+  cd tutorials
+  ```
+
+  Start Flink and Kafka:
 
   ```shell
   docker compose -f ./docker/docker-compose-flinksql.yml up -d
@@ -134,88 +148,7 @@ Run the following command to execute [FlinkSqlTopNTest#testTopN](src/test/java/i
       'key.fields' = 'id',
       'value.format' = 'json',
       'value.fields-include' = 'EXCEPT_KEY'
-);
-
-  ```
-
-  ```sql
-  INSERT INTO movie_views (id, title, genre, movie_start)
-  VALUES (123, 'The Dark Knight', 'Action', TO_TIMESTAMP('2024-04-23 19:04:00')),
-         (456, 'Avengers: Endgame', 'Action', TO_TIMESTAMP('2024-04-23 22:01:00')),
-         (789, 'Inception', 'Sci-Fi', TO_TIMESTAMP('2024-04-23 20:24:00')),
-         (147, 'Joker', 'Drama', TO_TIMESTAMP('2024-04-23 22:56:00')),
-         (258, 'The Godfather', 'Crime', TO_TIMESTAMP('2024-04-23 19:13:00')),
-         (369, 'Casablanca', 'Romance', TO_TIMESTAMP('2024-04-23 20:26:00')),
-         (321, 'The Shawshank Redemption', 'Drama', TO_TIMESTAMP('2024-04-23 20:20:00')),
-         (654, 'Forrest Gump', 'Drama', TO_TIMESTAMP('2024-04-23 21:54:00')),
-         (135, 'Pulp Fiction', 'Crime', TO_TIMESTAMP('2024-04-23 22:09:00')),
-         (246, 'The Godfather: Part II', 'Crime', TO_TIMESTAMP('2024-04-23 19:28:00')),
-         (842, 'Toy Story 3', 'Animation', TO_TIMESTAMP('2024-04-23 23:12:00')),
-         (931, 'Up', 'Animation', TO_TIMESTAMP('2024-04-23 22:17:00')),
-         (624, 'The Lion King', 'Animation', TO_TIMESTAMP('2024-04-23 22:28:00')),
-         (512, 'Star Wars: The Force Awakens', 'Sci-Fi', TO_TIMESTAMP('2024-04-23 20:42:00')),
-         (678, 'The Matrix', 'Sci-Fi', TO_TIMESTAMP('2024-04-23 19:25:00')),
-         (753, 'Interstellar', 'Sci-Fi', TO_TIMESTAMP('2024-04-23 20:14:00')),
-         (834, 'Titanic', 'Romance', TO_TIMESTAMP('2024-04-23 20:25:00')),
-         (333, 'The Pride of Archbishop Carroll', 'History', TO_TIMESTAMP('2024-04-24 03:37:00'));
-  ```
-
-```sql
-SELECT  *
-FROM (
-       SELECT *, ROW_NUMBER() OVER (PARTITION BY window_start, window_end ORDER BY category_count DESC ) as hour_rank
-       FROM (
-              SELECT window_start, window_end, genre, COUNT(*) as category_count
-                  FROM TABLE(TUMBLE(TABLE movie_views, DESCRIPTOR(movie_start), INTERVAL '1' HOUR))
-              GROUP BY window_start, window_end, genre
-        )
-) WHERE hour_rank = 1 ;
-  ```
-
-  The query output should look like this:
-
-  ```plaintext
-              window_start         window_end         genre      category_count    hour_rank 
-          2024-04-23 19:00:00  2024-04-23 20:00:00    Crime           2               1 
-          2024-04-23 20:00:00  2024-04-23 21:00:00    Sci-Fi          3               1 
-          2024-04-23 21:00:00  2024-04-23 22:00:00    Drama           1               1 
-          2024-04-23 22:00:00  2024-04-23 23:00:00    Animation       2               1 
-          2024-04-23 23:00:00  2024-04-24 00:00:00    Animation       1               1   
-  ```
-
-  When you are finished, clean up the containers used for this tutorial by running:
-
-  ```shell
-  docker compose -f ./docker/docker-compose-flinksql.yml down
-  ```
-
-</details>
-
-<details>
-  <summary>Confluent Cloud</summary>
-
-  #### Prerequisites
-
-  * A [Confluent Cloud](https://confluent.cloud/signup) account
-  * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
-
-  #### Run the commands
-
-  In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
-  pool that you have created.
-
-  Select the default catalog (Confluent Cloud environment) and database (Kafka cluster) to use with the dropdowns at the top right.
-
-  Finally, run following SQL statements to create the `movie_views` table, populate it with test data, and run the windowed Top-N query.
-
-  ```sql
- CREATE TABLE movie_views (
-        id INT,
-        title STRING,
-        genre STRING,
-        movie_start TIMESTAMP(3),
-        WATERMARK FOR movie_start as movie_start
- )
+  );
   ```
 
   ```sql
@@ -243,14 +176,92 @@ FROM (
   ```sql
   SELECT  *
   FROM (
-         SELECT *, ROW_NUMBER() OVER (PARTITION BY window_start, window_end ORDER BY category_count DESC ) as hour_rank
-         FROM (
-                SELECT window_start, window_end, genre, COUNT(*) as category_count
-                   FROM TABLE(TUMBLE(TABLE movie_views, DESCRIPTOR(movie_start), INTERVAL '1' HOUR))
-                GROUP BY window_start, window_end, genre
-        )
-) WHERE hour_rank = 1 ;
+      SELECT *, ROW_NUMBER() OVER (PARTITION BY window_start, window_end ORDER BY category_count DESC ) as hour_rank
+      FROM (
+          SELECT window_start, window_end, genre, COUNT(*) as category_count
+          FROM TABLE(TUMBLE(TABLE movie_views, DESCRIPTOR(movie_start), INTERVAL '1' HOUR))
+          GROUP BY window_start, window_end, genre
+      )
+  ) WHERE hour_rank = 1 ;
+  ```
 
+  The query output should look like this:
+
+  ```plaintext
+              window_start         window_end         genre      category_count    hour_rank 
+          2024-04-23 19:00:00  2024-04-23 20:00:00    Crime           2               1 
+          2024-04-23 20:00:00  2024-04-23 21:00:00    Sci-Fi          3               1 
+          2024-04-23 21:00:00  2024-04-23 22:00:00    Drama           1               1 
+          2024-04-23 22:00:00  2024-04-23 23:00:00    Animation       2               1 
+          2024-04-23 23:00:00  2024-04-24 00:00:00    Animation       1               1   
+  ```
+
+  When you are finished, clean up the containers used for this tutorial by running:
+
+  ```shell
+  docker compose -f ./docker/docker-compose-flinksql.yml down
+  ```
+</details>
+
+<details>
+  <summary>Confluent Cloud</summary>
+
+  ### Prerequisites
+
+  * A [Confluent Cloud](https://confluent.cloud/signup) account
+  * A Flink compute pool created in Confluent Cloud. Follow [this](https://docs.confluent.io/cloud/current/flink/get-started/quick-start-cloud-console.html) quick start to create one.
+
+  ### Run the commands
+
+  In the Confluent Cloud Console, navigate to your environment and then click the `Open SQL Workspace` button for the compute
+  pool that you have created.
+
+  Select the default catalog (Confluent Cloud environment) and database (Kafka cluster) to use with the dropdowns at the top right.
+
+  Finally, run following SQL statements to create the `movie_views` table, populate it with test data, and run the windowed Top-N query.
+
+  ```sql
+  CREATE TABLE movie_views (
+      id INT,
+      title STRING,
+      genre STRING,
+      movie_start TIMESTAMP(3),
+      WATERMARK FOR movie_start as movie_start
+  )
+  ```
+
+  ```sql
+  INSERT INTO movie_views (id, title, genre, movie_start)
+  VALUES (123, 'The Dark Knight', 'Action', TO_TIMESTAMP('2024-04-23 19:04:00')),
+         (456, 'Avengers: Endgame', 'Action', TO_TIMESTAMP('2024-04-23 22:01:00')),
+         (789, 'Inception', 'Sci-Fi', TO_TIMESTAMP('2024-04-23 20:24:00')),
+         (147, 'Joker', 'Drama', TO_TIMESTAMP('2024-04-23 22:56:00')),
+         (258, 'The Godfather', 'Crime', TO_TIMESTAMP('2024-04-23 19:13:00')),
+         (369, 'Casablanca', 'Romance', TO_TIMESTAMP('2024-04-23 20:26:00')),
+         (321, 'The Shawshank Redemption', 'Drama', TO_TIMESTAMP('2024-04-23 20:20:00')),
+         (654, 'Forrest Gump', 'Drama', TO_TIMESTAMP('2024-04-23 21:54:00')),
+         (135, 'Pulp Fiction', 'Crime', TO_TIMESTAMP('2024-04-23 22:09:00')),
+         (246, 'The Godfather: Part II', 'Crime', TO_TIMESTAMP('2024-04-23 19:28:00')),
+         (842, 'Toy Story 3', 'Animation', TO_TIMESTAMP('2024-04-23 23:12:00')),
+         (931, 'Up', 'Animation', TO_TIMESTAMP('2024-04-23 22:17:00')),
+         (624, 'The Lion King', 'Animation', TO_TIMESTAMP('2024-04-23 22:28:00')),
+         (512, 'Star Wars: The Force Awakens', 'Sci-Fi', TO_TIMESTAMP('2024-04-23 20:42:00')),
+         (678, 'The Matrix', 'Sci-Fi', TO_TIMESTAMP('2024-04-23 19:25:00')),
+         (753, 'Interstellar', 'Sci-Fi', TO_TIMESTAMP('2024-04-23 20:14:00')),
+         (834, 'Titanic', 'Romance', TO_TIMESTAMP('2024-04-23 20:25:00')),
+         (333, 'The Pride of Archbishop Carroll', 'History', TO_TIMESTAMP('2024-04-24 03:37:00'));
+  ```
+
+  ```sql
+  SELECT  *
+  FROM (
+      SELECT *, ROW_NUMBER() OVER (PARTITION BY window_start, window_end ORDER BY category_count DESC ) as hour_rank
+      FROM (
+          SELECT window_start, window_end, genre, COUNT(*) as category_count
+          FROM TABLE(TUMBLE(TABLE movie_views, DESCRIPTOR(movie_start), INTERVAL '1' HOUR))
+          GROUP BY window_start, window_end, genre
+      )
+  ) WHERE hour_rank = 1 ;
   ```
 
   The query output should look like this:


### PR DESCRIPTION
* fix: add repo clone instructions to Flink tutorials

* fix: improve header font in Flink SQL run instructions